### PR TITLE
Changing the master and slave vocabulary

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Permission
 class TwzwGamelistSerializer(serializers.ModelSerializer):
     class Meta:
         model =  TwzwGamelist
-        fields = ('options','serverid','gamedir','server_port','db_port','serverip','domain_name','gamename','slave_db'
+        fields = ('options','serverid','gamedir','server_port','db_port','serverip','domain_name','gamename','subordinate_db'
                   ,'message','c_time')
 
 class UserSerializer(serializers.ModelSerializer):

--- a/gamelist/migrations/0001_initial.py
+++ b/gamelist/migrations/0001_initial.py
@@ -48,7 +48,7 @@ class Migration(migrations.Migration):
                 ('serverip', models.CharField(max_length=128, verbose_name='游戏服ip')),
                 ('domain_name', models.CharField(max_length=256, verbose_name='域名')),
                 ('gamename', models.CharField(max_length=256, verbose_name='游戏服名字')),
-                ('slave_db', models.CharField(max_length=256, verbose_name='游戏服从库ip')),
+                ('subordinate_db', models.CharField(max_length=256, verbose_name='游戏服从库ip')),
                 ('message', models.CharField(max_length=256, verbose_name='附加信息')),
                 ('c_time', models.DateTimeField(auto_now_add=True)),
             ],

--- a/gamelist/models.py
+++ b/gamelist/models.py
@@ -12,7 +12,7 @@ class TwzwGamelist(models.Model):
     serverip = models.CharField(max_length=128,verbose_name="游戏服ip")
     domain_name = models.CharField(max_length=256,verbose_name="域名")
     gamename = models.CharField(max_length=256,verbose_name="游戏服名字")
-    slave_db = models.CharField(max_length=256,verbose_name="游戏服从库ip")
+    subordinate_db = models.CharField(max_length=256,verbose_name="游戏服从库ip")
     message = models.CharField(max_length=256,verbose_name="附加信息")
     c_time = models.DateTimeField(auto_now_add=True)
 

--- a/gamelist/views.py
+++ b/gamelist/views.py
@@ -90,7 +90,7 @@ def table_req_data_api(request):
                         "serverip": row.serverip,
                         "domain_name": row.domain_name,
                         "gamename": row.gamename,
-                        "slave_db": row.slave_db,
+                        "subordinate_db": row.subordinate_db,
                         "message": row.message
                     })
                 return JsonResponse(data)
@@ -115,7 +115,7 @@ def table_req_data_api(request):
                         "serverip": row.serverip,
                         "domain_name": row.domain_name,
                         "gamename": row.gamename,
-                        "slave_db": row.slave_db,
+                        "subordinate_db": row.subordinate_db,
                         "message": row.message
                         })
                 return JsonResponse(data)
@@ -138,7 +138,7 @@ def table_req_data_api(request):
                     "serverip": row.serverip,
                     "domain_name": row.domain_name,
                     "gamename": row.gamename,
-                    "slave_db": row.slave_db,
+                    "subordinate_db": row.subordinate_db,
                     "message": row.message
                 })
             return JsonResponse(data)
@@ -161,7 +161,7 @@ def api_twzwtable(request):
         serverip = request.POST.get('serverip')
         domain_name = request.POST.get('domain_name')
         gamename = request.POST.get('gamename')
-        slave_db = request.POST.get('slave_db')
+        subordinate_db = request.POST.get('subordinate_db')
         message = request.POST.get('message')
 
         try:
@@ -174,7 +174,7 @@ def api_twzwtable(request):
                 serverip=serverip,
                 domain_name=domain_name,
                 gamename=gamename,
-                slave_db=slave_db,
+                subordinate_db=subordinate_db,
                 message=message
             )
             return HttpResponse('添加成功')


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.